### PR TITLE
Remove 'resource available' message

### DIFF
--- a/lib/avalon/workflow/workflow_controller_behavior.rb
+++ b/lib/avalon/workflow/workflow_controller_behavior.rb
@@ -114,7 +114,6 @@ module Avalon::Workflow::WorkflowControllerBehavior
     unless HYDRANT_STEPS.last?(params[:step]) && @active_step == "published"
       redirect_path = edit_polymorphic_path(obj, step: target)
     else
-      flash[:notice] = "This resource is now available for use in the system"
       redirect_path = polymorphic_path(obj)
     end
 


### PR DESCRIPTION
When this message pops up, the resource isn't actually available yet. I didn't replace the message with a processing message. It's already obvious because of the progress bar. 
