### PR TITLE
Reinitialize context and rerun custom_edit when rendering edit view due to failed update

### DIFF
--- a/lib/avalon/workflow/workflow_controller_behavior.rb
+++ b/lib/avalon/workflow/workflow_controller_behavior.rb
@@ -72,7 +72,8 @@ module Avalon::Workflow::WorkflowControllerBehavior
           flash.now[:error] = 'There are errors with your submission. Please correct them before continuing.'
 
           # Refresh the context before rendering edit
-          context = perform_step_action :before_step
+          context = HYDRANT_STEPS.get_step(@active_step).send(:before_step, context)
+          context_to_instance_variables context
           custom_edit #yield to custom_edit in the controller
 
           render :edit

--- a/lib/avalon/workflow/workflow_controller_behavior.rb
+++ b/lib/avalon/workflow/workflow_controller_behavior.rb
@@ -70,6 +70,11 @@ module Avalon::Workflow::WorkflowControllerBehavior
         flashes = { error: context[:error], notice: context[:notice]}
         if model_object.errors.present?
           flash.now[:error] = 'There are errors with your submission. Please correct them before continuing.'
+
+          # Refresh the context before rendering edit
+          context = perform_step_action :before_step
+          custom_edit #yield to custom_edit in the controller
+
           render :edit
         elsif model_object.workflow.published? && model_object.workflow.current?(@active_step)
           redirect_to(polymorphic_path(model_object), flash: flashes)


### PR DESCRIPTION
This avoids the need for setup at the end of execute actions in steps.

Part of https://github.com/avalonmediasystem/avalon/issues/6071